### PR TITLE
feat: Build CLI pipeline entrypoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -55,7 +55,49 @@ def setup_output_dir(output_dir):
 
 def process_buildings(buildings_path, output_dir):
     """Loads buildings and returns df of processed buildings"""
-    buildings_df = data_collection.load_buildings_csv(str(buildings_path))
+    # Ensure output directory exists
+    output_dir.mkdir(parents=True, exist_ok=True)
+    # Load the CSV
+    try:
+        buildings_df = data_collection.load_buildings_csv(str(buildings_path))
+    except Exception as e:
+        print(f"Error loading buildings file: {e}")
+        print("Please check that your CSV has the required columns: building_name, latitude, longitude")
+        raise  # Re-raise to stop the pipeline
+    # VALIDATION STEP 1: Check required columns exist
+    required_columns = ["building_name", "latitude", "longitude"]
+    missing_columns = [col for col in required_columns if col not in buildings_df.columns]
+    if missing_columns:
+        print(f"Error: Buildings CSV is missing required columns: {missing_columns}")
+        print(f"Your CSV has columns: {list(buildings_df.columns)}")
+        print("Please ensure your CSV includes: building_name, latitude, longitude")
+        raise ValueError(f"Missing required columns: {missing_columns}")
+    if len(buildings_df) > 0:
+        # VALIDATION STEP 2: Check latitude/longitude are numeric
+        for col in ["latitude", "longitude"]:
+            if not pd.api.types.is_numeric_dtype(buildings_df[col]):
+                print(f"Error: Column '{col}' must contain numbers")
+                print(f"Found values: {buildings_df[col].head()}")
+                raise ValueError(f"Column '{col}' is not numeric")
+        # VALIDATION STEP 3: Check for missing values
+        for col in ["latitude", "longitude"]:
+            if buildings_df[col].isna().any():
+                print(f"Warning: Some buildings have missing {col} values")
+                # Either drop them or fill with defaults - let's drop for now
+                buildings_df = buildings_df.dropna(subset=[col])
+                print(f"Dropped rows with missing {col}. {len(buildings_df)} buildings remaining")
+    # VALIDATION STEP 4: Ensure building_id exists
+    if "building_id" not in buildings_df.columns:
+        print("Note: 'building_id' not found in CSV, generating from building_name")
+        buildings_df["building_id"] = buildings_df["building_name"].apply(data_collection.slugify_building_name)
+    # VALIDATION STEP 5: Check for duplicate building_ids
+    if len(buildings_df) > 0 and buildings_df["building_id"].duplicated().any():
+        duplicates = buildings_df[buildings_df["building_id"].duplicated(keep=False)]
+        print(f"Warning: Found duplicate building_ids:")
+        for _, row in duplicates.iterrows():
+            print(f"  - {row['building_name']} → {row['building_id']}")
+        print("Routes may be ambiguous. Consider making building names more unique.")
+    # Save the validated data
     buildings_output = output_dir / "buildings.csv"
     export_csv.export_dataframe(buildings_df, str(buildings_output))
     print(f"Saved {len(buildings_df)} buildings to {buildings_output}")
@@ -64,7 +106,13 @@ def process_buildings(buildings_path, output_dir):
 def build_graph(boundary_path, output_dir):
     """Build walking path graph and save edges to csv"""
     output_dir.mkdir(parents=True, exist_ok=True)
-    graph = graph_builder.build_walking_graph_from_polygon(str(boundary_path))
+    try:
+        graph = graph_builder.build_walking_graph_from_polygon(str(boundary_path))
+        print("Graph built successfully")
+    except Exception as e:
+        print(f"Error: {e}")
+        print("Proceeding with empty graph_edges.csv")
+        graph = None
     edges_df = pd.DataFrame(columns=["from_node", "to_node", "distance_m"])
     if graph is not None and graph.number_of_nodes() > 0:
         print(f"Graph built with {graph.number_of_nodes()} nodes")

--- a/main.py
+++ b/main.py
@@ -1,0 +1,166 @@
+"""CLI entrypoint for the routing pipeline"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+from src import data_collection, graph_builder, router, export_csv
+
+def parse_arguments():
+    """Set up and parse command line arguments"""
+    parser = argparse.ArgumentParser(
+        description="CU Routing Pipeline - Generate campus walking routes"
+    )
+    parser.add_argument(
+        "--input", "-i",
+        required=True,
+        help="Path to the buildings csv input file"
+    )
+    parser.add_argument(
+        "--boundary", "-b",
+        required=True,
+        help="Path to campus boundary GeoJSON file"
+    )
+    parser.add_argument(
+        "--output", "-o",
+        required=True,
+        help="Output directory for csv files (would be created if it does not exist)"
+    )
+    return parser.parse_args()
+
+def validate_files_exist(buildings_path, boundary_path):
+    """Check the existence of input files"""
+    if not buildings_path.exists():
+        print("Error: Buildings file does not exist")
+        return False
+    if not boundary_path.exists():
+        print("Error: Boundary file does not exist")
+        return False
+    return True
+
+def setup_output_dir(output_dir):
+    """Sets up the output directory for csv outputs if given path not found"""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    return output_dir
+
+def process_buildings(buildings_path, output_dir):
+    """Loads buildings and returns df of processed buildings"""
+    buildings_df = data_collection.load_buildings_csv(str(buildings_path))
+    buildings_output = output_dir / "buildings.csv"
+    export_csv.export_dataframe(buildings_df, str(buildings_output))
+    print(f"Saved {len(buildings_df)} buildings to {buildings_output}")
+    return buildings_df
+
+def build_graph(boundary_path, output_dir):
+    """Build walking path graph and save edges to csv"""
+    graph = graph_builder.build_walking_graph_from_polygon(str(boundary_path))
+    if graph.number_of_nodes() == 0:
+        print("Warning: Graph is empty (placeholder implementation)")
+        edges_df = pd.DataFrame(columns=["from_node", "to_node", "distance_m"])
+    else:
+        print(f"graph built with {graph.number_of_nodes()} nodes")
+        edges_data = []
+        for u, v, data in graph.edges(data=True):
+            edges_data.append({
+                "from_node": u,
+                "to_node": v,
+                "distance_m": data.get("distance_m", data.get("length", 0))
+            })
+        edges_df = pd.DataFrame(edges_data)
+    edges_output = output_dir / "graph_edges.csv"
+    export_csv.export_dataframe(edges_df, str(edges_output))
+    print(f"Saved {len(edges_df)} edges to {edges_output}")
+    return graph
+
+def calculate_routes(graph, buildings_df, output_dir, walking_speed_kmh=5):
+    """Calculate routes for buildings and return a dataframe of routes
+    NOTE: walking speed of 5 was assigned as a placeholder"""
+    try:
+        # Test if routing is possible
+        test_node = router.map_building_to_nearest_node(
+            graph,
+            buildings_df.iloc[0]['latitude'],
+            buildings_df.iloc[0]['longitude']
+        )
+        # Calculate ALL routes
+        n_buildings = len(buildings_df)
+        routes_data = []
+        for i in range(n_buildings):
+            for j in range(i+1, n_buildings):
+                b1 = buildings_df.iloc[i]
+                b2 = buildings_df.iloc[j]
+                try:
+                    node1 = router.map_building_to_nearest_node(graph, b1["latitude"], b1["longitude"])
+                    node2 = router.map_building_to_nearest_node(graph, b2["latitude"], b2["longitude"])
+                    path, distance = router.find_shortest_path(graph, node1, node2)
+                    path_nodes_str = ";".join(str(node) for node in path)
+                    estimated_time_min = (distance/1000) / (walking_speed_kmh/60)
+                    # TODO: When building-to-node mapping is available
+                    path_buildings_str = ""
+                    routes_data.append({
+                        "origin_building_id": b1["building_id"],
+                        "destination_building_id": b2["building_id"],
+                        "algorithm": "dijkstra",
+                        "distance_m": round(distance, 2),
+                        "estimated_time_min": round(estimated_time_min, 2),
+                            "path_node_count": len(path),
+                        "path_nodes": path_nodes_str,
+                        "path_buildings": path_buildings_str,
+                        "computed_at": pd.Timestamp.now().isoformat()
+                    })
+                except Exception as e:
+                    print(f"Skipped building{b1['building_id']} -> building{b2['building_id']}: {e}")
+                    continue
+        routes_df = pd.DataFrame(routes_data)
+        print(f"Successfully calculated {len(routes_df)} routes")
+    except NotImplementedError:
+        print("Nearest-node mapping not implemented")
+        print("Creating routes.csv with correct schema but no data")
+        routes_df = pd.DataFrame(columns=[
+            'origin_building_id', 'destination_building_id',
+            'algorithm', 'distance_m', 'estimated_time_min',
+            'path_node_count', 'path_nodes', 'path_buildings',
+            'computed_at'
+        ])
+    except Exception as e:
+        print(f"Unexpected error: {e}")
+        routes_df = pd.DataFrame(columns=[
+            'origin_building_id', 'destination_building_id',
+            'algorithm', 'distance_m', 'estimated_time_min',
+            'path_node_count', 'path_nodes', 'path_buildings',
+            'computed_at'
+        ])
+    routes_output = output_dir / "routes.csv"
+    export_csv.export_dataframe(routes_df, str(routes_output))
+    print(f"Saved {len(routes_df)} routes to {routes_output}")
+    return routes_df
+
+def main():
+    """Main pipeline execution function - Orchestrates all steps"""
+    args = parse_arguments()
+    buildings_path = Path(args.input)
+    boundary_path = Path(args.boundary)
+    output_dir = Path(args.output)
+    if not validate_files_exist(buildings_path, boundary_path):
+        return 1
+    setup_output_dir(output_dir)
+    try:
+        print("Processing buildings...")
+        buildings_df = process_buildings(buildings_path, output_dir)
+        print("Creating graph...")
+        graph = build_graph(boundary_path, output_dir)
+        print("Calculating routes...")
+        routes_df = calculate_routes(graph, buildings_df, output_dir)
+        print("Process Successful")
+        return 0
+    except Exception as e:
+        print(f"Unexpected error: {e}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/main.py
+++ b/main.py
@@ -37,8 +37,14 @@ def validate_files_exist(buildings_path, boundary_path):
     if not buildings_path.exists():
         print("Error: Buildings file does not exist")
         return False
+    if not buildings_path.is_file():  # Add this!
+        print(f"Error: Buildings path is not a file: {buildings_path}")
+        return False
     if not boundary_path.exists():
         print("Error: Boundary file does not exist")
+        return False
+    if not boundary_path.is_file():  # Add this!
+        print(f"Error: Boundary path is not a file: {boundary_path}")
         return False
     return True
 
@@ -57,12 +63,11 @@ def process_buildings(buildings_path, output_dir):
 
 def build_graph(boundary_path, output_dir):
     """Build walking path graph and save edges to csv"""
+    output_dir.mkdir(parents=True, exist_ok=True)
     graph = graph_builder.build_walking_graph_from_polygon(str(boundary_path))
-    if graph.number_of_nodes() == 0:
-        print("Warning: Graph is empty (placeholder implementation)")
-        edges_df = pd.DataFrame(columns=["from_node", "to_node", "distance_m"])
-    else:
-        print(f"graph built with {graph.number_of_nodes()} nodes")
+    edges_df = pd.DataFrame(columns=["from_node", "to_node", "distance_m"])
+    if graph is not None and graph.number_of_nodes() > 0:
+        print(f"Graph built with {graph.number_of_nodes()} nodes")
         edges_data = []
         for u, v, data in graph.edges(data=True):
             edges_data.append({
@@ -70,7 +75,10 @@ def build_graph(boundary_path, output_dir):
                 "to_node": v,
                 "distance_m": data.get("distance_m", data.get("length", 0))
             })
-        edges_df = pd.DataFrame(edges_data)
+        if edges_data:
+            edges_df = pd.DataFrame(edges_data, columns=["from_node", "to_node", "distance_m"])
+    else:
+        print("Warning -> Graph is empty/None. Using empty edges.csv")
     edges_output = output_dir / "graph_edges.csv"
     export_csv.export_dataframe(edges_df, str(edges_output))
     print(f"Saved {len(edges_df)} edges to {edges_output}")
@@ -79,61 +87,68 @@ def build_graph(boundary_path, output_dir):
 def calculate_routes(graph, buildings_df, output_dir, walking_speed_kmh=5):
     """Calculate routes for buildings and return a dataframe of routes
     NOTE: walking speed of 5 was assigned as a placeholder"""
-    try:
-        # Test if routing is possible
-        test_node = router.map_building_to_nearest_node(
-            graph,
-            buildings_df.iloc[0]['latitude'],
-            buildings_df.iloc[0]['longitude']
-        )
-        # Calculate ALL routes
-        n_buildings = len(buildings_df)
-        routes_data = []
-        for i in range(n_buildings):
-            for j in range(i+1, n_buildings):
-                b1 = buildings_df.iloc[i]
-                b2 = buildings_df.iloc[j]
-                try:
-                    node1 = router.map_building_to_nearest_node(graph, b1["latitude"], b1["longitude"])
-                    node2 = router.map_building_to_nearest_node(graph, b2["latitude"], b2["longitude"])
-                    path, distance = router.find_shortest_path(graph, node1, node2)
-                    path_nodes_str = ";".join(str(node) for node in path)
-                    estimated_time_min = (distance/1000) / (walking_speed_kmh/60)
-                    # TODO: When building-to-node mapping is available
-                    path_buildings_str = ""
-                    routes_data.append({
-                        "origin_building_id": b1["building_id"],
-                        "destination_building_id": b2["building_id"],
-                        "algorithm": "dijkstra",
-                        "distance_m": round(distance, 2),
-                        "estimated_time_min": round(estimated_time_min, 2),
-                            "path_node_count": len(path),
-                        "path_nodes": path_nodes_str,
-                        "path_buildings": path_buildings_str,
-                        "computed_at": pd.Timestamp.now().isoformat()
-                    })
-                except Exception as e:
-                    print(f"Skipped building{b1['building_id']} -> building{b2['building_id']}: {e}")
-                    continue
-        routes_df = pd.DataFrame(routes_data)
-        print(f"Successfully calculated {len(routes_df)} routes")
-    except NotImplementedError:
-        print("Nearest-node mapping not implemented")
-        print("Creating routes.csv with correct schema but no data")
-        routes_df = pd.DataFrame(columns=[
-            'origin_building_id', 'destination_building_id',
-            'algorithm', 'distance_m', 'estimated_time_min',
-            'path_node_count', 'path_nodes', 'path_buildings',
-            'computed_at'
-        ])
-    except Exception as e:
-        print(f"Unexpected error: {e}")
-        routes_df = pd.DataFrame(columns=[
-            'origin_building_id', 'destination_building_id',
-            'algorithm', 'distance_m', 'estimated_time_min',
-            'path_node_count', 'path_nodes', 'path_buildings',
-            'computed_at'
-        ])
+    schema = [
+        'origin_building_id', 'destination_building_id',
+        'algorithm', 'distance_m', 'estimated_time_min',
+        'path_node_count', 'path_nodes', 'path_buildings',
+        'computed_at'
+    ]
+    output_dir.mkdir(parents=True, exist_ok=True)
+    if len(buildings_df) < 2:
+        print(f"Only {len(buildings_df)} building(s) - no routes to calculate")
+        routes_df = pd.DataFrame(columns=schema)
+        routes_output = output_dir / "routes.csv"
+        export_csv.export_dataframe(routes_df, str(routes_output))
+        print(f"Saved {len(routes_df)} routes to {routes_output}")
+        return routes_df
+    if graph is None or graph.number_of_nodes() == 0:
+        print("Graph not available. Creating empty routes.csv with correct schema")
+        routes_df = pd.DataFrame(columns=schema)
+        routes_output = output_dir / "routes.csv"
+        export_csv.export_dataframe(routes_df, str(routes_output))
+        print(f"Saved {len(routes_df)} routes to {routes_output}")
+        return routes_df
+    routes_data = []
+    total_pairs = len(buildings_df) * (len(buildings_df) - 1) // 2
+    print(f"Calculating {total_pairs} routes...")
+    for i in range(len(buildings_df)):
+        for j in range(i+1, len(buildings_df)):
+            b1 = buildings_df.iloc[i]
+            b2 = buildings_df.iloc[j]
+            try:
+                node1 = router.map_building_to_nearest_node(graph, b1["latitude"], b1["longitude"])
+                node2 = router.map_building_to_nearest_node(graph, b2["latitude"], b2["longitude"])
+                path, distance = router.find_shortest_path(graph, node1, node2)
+                path_nodes_str = ";".join(str(node) for node in path)
+                estimated_time_min = (distance/1000)/(walking_speed_kmh/60)
+                # TODO: When building-to-node mapping is available
+                path_buildings_str = ""
+                routes_data.append({
+                    "origin_building_id": b1["building_id"],
+                    "destination_building_id": b2["building_id"],
+                    "algorithm": "dijkstra",
+                    "distance_m": round(distance, 2),
+                    "estimated_time_min": round(estimated_time_min, 2),
+                    "path_node_count": len(path),
+                    "path_nodes": path_nodes_str,
+                    "path_buildings": path_buildings_str,
+                    "computed_at": pd.Timestamp.now().isoformat()
+                })
+            except NotImplementedError:
+                print("Nearest-node mapping not implemented - stopping route calculation")
+                break
+            except Exception as e:
+                print(f"Skipped {b1['building_id']} -> {b2['building_id']}: {e}")
+                continue
+        else:
+            continue
+        break
+    if routes_data:
+        routes_df = pd.DataFrame(routes_data, columns=schema)
+        print(f"Successfully calculated {len(routes_df)} routes.")
+    else:
+        print("No routes could be calculated - creating empty routes.csv with correct schema")
+        routes_df = pd.DataFrame(columns=schema)
     routes_output = output_dir / "routes.csv"
     export_csv.export_dataframe(routes_df, str(routes_output))
     print(f"Saved {len(routes_df)} routes to {routes_output}")
@@ -160,7 +175,6 @@ def main():
     except Exception as e:
         print(f"Unexpected error: {e}")
         return 1
-
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,5 @@
 """Tests for main.py CLI pipeline"""
+import sys
 import tempfile
 from pathlib import Path
 import pandas as pd
@@ -111,3 +112,109 @@ def test_main_runs_without_crashing():
         assert (output_dir / "buildings.csv").exists()
         assert (output_dir / "graph_edges.csv").exists()
         assert (output_dir / "routes.csv").exists()
+
+# NEW TEST 1: routes.csv has expected columns when 0 buildings
+def test_routes_csv_columns_with_zero_buildings():
+    """Test that routes.csv has correct columns even with no buildings"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create empty buildings file (only headers)
+        buildings_file = Path(tmpdir) / "buildings.csv"
+        pd.DataFrame(columns=['building_name', 'latitude', 'longitude']).to_csv(buildings_file, index=False)
+        boundary_file = Path(tmpdir) / "boundary.geojson"
+        boundary_file.touch()
+        output_dir = Path(tmpdir) / "output"
+        # Run main
+        sys.argv = ["main.py", "--input", str(buildings_file),
+                    "--boundary", str(boundary_file), "--output", str(output_dir)]
+        main.main()
+        # Check routes.csv exists and has correct columns
+        routes_file = output_dir / "routes.csv"
+        assert routes_file.exists()
+        routes_df = pd.read_csv(routes_file)
+        expected_columns = [
+            'origin_building_id', 'destination_building_id', 'algorithm',
+            'distance_m', 'estimated_time_min', 'path_node_count',
+            'path_nodes', 'path_buildings', 'computed_at'
+        ]
+        for col in expected_columns:
+            assert col in routes_df.columns, f"Missing column: {col}"
+
+# NEW TEST 2: routes.csv has expected columns when 1 building
+def test_routes_csv_columns_with_one_building():
+    """Test that routes.csv has correct columns with only one building"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create buildings file with 1 building
+        buildings_file = Path(tmpdir) / "buildings.csv"
+        pd.DataFrame({
+            'building_name': ['Library'],
+            'latitude': [6.6723],
+            'longitude': [3.1581]
+        }).to_csv(buildings_file, index=False)
+        boundary_file = Path(tmpdir) / "boundary.geojson"
+        boundary_file.touch()
+        output_dir = Path(tmpdir) / "output"
+        # Run main
+        sys.argv = ["main.py", "--input", str(buildings_file),
+                    "--boundary", str(boundary_file), "--output", str(output_dir)]
+        main.main()
+        # Check routes.csv exists and has correct columns
+        routes_file = output_dir / "routes.csv"
+        assert routes_file.exists()
+        routes_df = pd.read_csv(routes_file)
+        expected_columns = [
+            'origin_building_id', 'destination_building_id', 'algorithm',
+            'distance_m', 'estimated_time_min', 'path_node_count',
+            'path_nodes', 'path_buildings', 'computed_at'
+        ]
+        for col in expected_columns:
+            assert col in routes_df.columns, f"Missing column: {col}"
+        # Should have 0 routes (since only 1 building)
+        assert len(routes_df) == 0
+
+# NEW TEST 3: graph_edges.csv has expected columns when graph has zero edges
+def test_graph_edges_csv_columns_with_empty_graph():
+    """Test that graph_edges.csv has correct columns even when graph is empty"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create minimal input
+        buildings_file = Path(tmpdir) / "buildings.csv"
+        pd.DataFrame({
+            'building_name': ['Library'],
+            'latitude': [6.6723],
+            'longitude': [3.1581]
+        }).to_csv(buildings_file, index=False)
+        boundary_file = Path(tmpdir) / "boundary.geojson"
+        boundary_file.touch()
+        output_dir = Path(tmpdir) / "output"
+        # Run main
+        sys.argv = ["main.py", "--input", str(buildings_file),
+                    "--boundary", str(boundary_file), "--output", str(output_dir)]
+        main.main()
+        # Check graph_edges.csv exists and has correct columns
+        edges_file = output_dir / "graph_edges.csv"
+        assert edges_file.exists()
+        edges_df = pd.read_csv(edges_file)
+        expected_columns = ["from_node", "to_node", "distance_m"]
+        for col in expected_columns:
+            assert col in edges_df.columns, f"Missing column: {col}"
+
+# NEW TEST 4: validate_files_exist returns False for directories
+def test_validate_files_exist_with_directories():
+    """Test that validate_files_exist returns False when given directories instead of files"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create directories (not files)
+        buildings_dir = Path(tmpdir) / "buildings_dir"
+        boundary_dir = Path(tmpdir) / "boundary_dir"
+        buildings_dir.mkdir()
+        boundary_dir.mkdir()
+        # Validation should fail (these are directories, not files)
+        assert main.validate_files_exist(buildings_dir, boundary_dir) == False
+        # Create real files
+        buildings_file = Path(tmpdir) / "buildings.csv"
+        boundary_file = Path(tmpdir) / "boundary.geojson"
+        buildings_file.touch()
+        boundary_file.touch()
+        # Validation should pass
+        assert main.validate_files_exist(buildings_file, boundary_file) == True
+        # Mix one file, one directory should fail
+        assert main.validate_files_exist(buildings_file, boundary_dir) == False
+        assert main.validate_files_exist(buildings_dir, boundary_file) == False

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,113 @@
+"""Tests for main.py CLI pipeline"""
+import tempfile
+from pathlib import Path
+import pandas as pd
+import main
+
+def test_validate_files_exist_with_real_files():
+    """Test file validation with actual files"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create real files
+        buildings_file = Path(tmpdir) / "buildings.csv"
+        boundary_file = Path(tmpdir) / "boundary.geojson"
+        buildings_file.touch()
+        boundary_file.touch()
+        assert main.validate_files_exist(buildings_file, boundary_file) == True
+
+def test_validate_files_exist_with_missing_file():
+    """Test file validation when one file is missing"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        buildings_file = Path(tmpdir) / "buildings.csv"
+        boundary_file = Path(tmpdir) / "boundary.geojson"
+        buildings_file.touch()  # Only create one file
+        # boundary_file not created
+        assert main.validate_files_exist(buildings_file, boundary_file) == False
+
+def test_setup_output_dir_creates_directory():
+    """Test output directory creation"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        new_dir = Path(tmpdir) / "new" / "output" / "dir"
+        result = main.setup_output_dir(new_dir)
+        assert result == new_dir
+        assert new_dir.exists()
+
+def test_process_buildings_adds_ids_and_saves():
+    """Test buildings processing adds building_id and saves CSV"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create input CSV
+        input_file = Path(tmpdir) / "input.csv"
+        test_df = pd.DataFrame({
+            'building_name': ['Library', 'Cafe'],
+            'latitude': [6.6723, 6.6734],
+            'longitude': [3.1581, 3.1592]
+        })
+        test_df.to_csv(input_file, index=False)
+        # Process buildings
+        output_dir = Path(tmpdir) / "output"
+        result_df = main.process_buildings(input_file, output_dir)
+        # Check result
+        assert 'building_id' in result_df.columns
+        assert result_df['building_id'].iloc[0] == 'library'
+        assert result_df['building_id'].iloc[1] == 'cafe'
+        # Check file was saved
+        assert (output_dir / "buildings.csv").exists()
+
+
+def test_build_graph_creates_edges_csv():
+    """Test graph building creates edges CSV (even if empty)"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create dummy boundary file
+        boundary_file = Path(tmpdir) / "boundary.geojson"
+        boundary_file.touch()
+        # Build graph
+        output_dir = Path(tmpdir) / "output"
+        graph = main.build_graph(boundary_file, output_dir)
+        # Check edges file was created
+        assert (output_dir / "graph_edges.csv").exists()
+
+def test_calculate_routes_creates_routes_csv():
+    """Test route calculation creates routes CSV (even if empty)"""
+    # Create minimal test data
+    buildings_df = pd.DataFrame({
+        'building_id': ['lib', 'cafe'],
+        'building_name': ['Library', 'Cafe'],
+        'latitude': [6.6723, 6.6734],
+        'longitude': [3.1581, 3.1592]
+    })
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_dir = Path(tmpdir)
+        # Use None as graph (will trigger NotImplementedError path)
+        result_df = main.calculate_routes(None, buildings_df, output_dir)
+        # Check routes file was created
+        assert (output_dir / "routes.csv").exists()
+
+def test_main_runs_without_crashing():
+    """Test that main function runs without crashing"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create dummy input files
+        buildings_file = Path(tmpdir) / "buildings.csv"
+        boundary_file = Path(tmpdir) / "boundary.geojson"
+        # Create buildings CSV
+        pd.DataFrame({
+            'building_name': ['Library'],
+            'latitude': [6.6723],
+            'longitude': [3.1581]
+        }).to_csv(buildings_file, index=False)
+        boundary_file.touch()
+        output_dir = Path(tmpdir) / "output"
+        # Mock command line arguments
+        import sys
+        sys.argv = [
+            "main.py",
+            "--input", str(buildings_file),
+            "--boundary", str(boundary_file),
+            "--output", str(output_dir)
+        ]
+        # Run main
+        result = main.main()
+        # Should return 0 (success)
+        assert result == 0
+        # Check all output files created
+        assert (output_dir / "buildings.csv").exists()
+        assert (output_dir / "graph_edges.csv").exists()
+        assert (output_dir / "routes.csv").exists()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,6 +3,8 @@ import sys
 import tempfile
 from pathlib import Path
 import pandas as pd
+import pytest
+import unittest.mock
 import main
 
 def test_validate_files_exist_with_real_files():
@@ -57,12 +59,28 @@ def test_process_buildings_adds_ids_and_saves():
 def test_build_graph_creates_edges_csv():
     """Test graph building creates edges CSV (even if empty)"""
     with tempfile.TemporaryDirectory() as tmpdir:
-        # Create dummy boundary file
+        # Create a MINIMAL valid GeoJSON polygon
         boundary_file = Path(tmpdir) / "boundary.geojson"
-        boundary_file.touch()
+
+        # This is a tiny valid GeoJSON (a square around 0,0)
+        valid_geojson = {
+            "type": "Feature",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [[
+                    [0, 0], [1, 0], [1, 1], [0, 1], [0, 0]
+                ]]
+            }
+        }
+
+        import json
+        with open(boundary_file, 'w') as f:
+            json.dump(valid_geojson, f)
+
         # Build graph
         output_dir = Path(tmpdir) / "output"
         graph = main.build_graph(boundary_file, output_dir)
+
         # Check edges file was created
         assert (output_dir / "graph_edges.csv").exists()
 
@@ -218,3 +236,93 @@ def test_validate_files_exist_with_directories():
         # Mix one file, one directory should fail
         assert main.validate_files_exist(buildings_file, boundary_dir) == False
         assert main.validate_files_exist(buildings_dir, boundary_file) == False
+
+
+def test_build_graph_handles_exception():
+    """Test build_graph gracefully handles graph builder failures"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        boundary_file = Path(tmpdir) / "boundary.geojson"
+        boundary_file.touch()
+        output_dir = Path(tmpdir) / "output"
+        # Mock the graph builder to raise an exception
+        with unittest.mock.patch('src.graph_builder.build_walking_graph_from_polygon') as mock_builder:
+            mock_builder.side_effect = Exception("OSM connection failed")
+            # This should NOT crash
+            graph = main.build_graph(boundary_file, output_dir)
+            # Should return None
+            assert graph is None
+            # Should still create empty CSV with headers
+            edges_file = output_dir / "graph_edges.csv"
+            assert edges_file.exists()
+            edges_df = pd.read_csv(edges_file)
+            assert list(edges_df.columns) == ["from_node", "to_node", "distance_m"]
+            assert len(edges_df) == 0
+
+
+def test_process_buildings_missing_columns():
+    """Test process_buildings raises error when required columns missing"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create CSV missing required columns
+        bad_file = Path(tmpdir) / "bad.csv"
+        pd.DataFrame({
+            'wrong_name': ['Library'],
+            'lat': [6.6723],
+            'lon': [3.1581]
+        }).to_csv(bad_file, index=False)
+        output_dir = Path(tmpdir) / "output"
+        # Should raise error about missing columns
+        with pytest.raises(ValueError, match="Missing required columns"):
+            main.process_buildings(bad_file, output_dir)
+
+
+def test_calculate_routes_not_implemented():
+    """Test calculate_routes handles NotImplementedError gracefully"""
+    buildings_df = pd.DataFrame({
+        'building_id': ['lib', 'cafe'],
+        'building_name': ['Library', 'Cafe'],
+        'latitude': [6.6723, 6.6734],
+        'longitude': [3.1581, 3.1592]
+    })
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_dir = Path(tmpdir)
+        # Mock the router to raise NotImplementedError
+        with unittest.mock.patch('src.router.map_building_to_nearest_node') as mock_map:
+            mock_map.side_effect = NotImplementedError("Not implemented")
+            result_df = main.calculate_routes(None, buildings_df, output_dir)
+            # Should return empty DataFrame with correct schema
+            expected_columns = [
+                'origin_building_id', 'destination_building_id', 'algorithm',
+                'distance_m', 'estimated_time_min', 'path_node_count',
+                'path_nodes', 'path_buildings', 'computed_at'
+            ]
+            for col in expected_columns:
+                assert col in result_df.columns
+            assert len(result_df) == 0
+            # Should still create CSV
+            routes_file = output_dir / "routes.csv"
+            assert routes_file.exists()
+
+
+def test_main_returns_1_on_validation_failure():
+    """Test main returns 1 (error) when file validation fails"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create only one file (other missing)
+        buildings_file = Path(tmpdir) / "buildings.csv"
+        buildings_file.touch()
+        # boundary_file not created
+        output_dir = Path(tmpdir) / "output"
+        # Mock args to point to non-existent boundary file
+        import sys
+        sys.argv = [
+            "main.py",
+            "--input", str(buildings_file),
+            "--boundary", str(Path(tmpdir) / "missing.geojson"),
+            "--output", str(output_dir)
+        ]
+        # Main should return 1 (error)
+        result = main.main()
+        assert result == 1
+        # No output files should be created
+        assert not (output_dir / "buildings.csv").exists()
+        assert not (output_dir / "graph_edges.csv").exists()
+        assert not (output_dir / "routes.csv").exists()


### PR DESCRIPTION
- Creates main.py to run complete end to end pipeline
- CLI accepts input/output paths
- Processes buildings, builds graph, calculates all routes
- Exports buildings.csv, graph_edges.csv, routes.csv
- Adds tests/test_main.py for pipeline validation
- Handles errors and placeholder functions gacefully

Closes #11

## Summary
- What changed?
- Added CLI pipeline entry point (main.py) that runs the complete routing process end-to-end.
- Why?
- To provide a single command that processes buildings, builds graphs, and calculates all routes, exporting the three required CSV files.

## Linked Issue
Closes #11

## Checklist
- [ ] My PR is focused on one issue only
- [ ] I added or updated tests where needed
- [ ] I ran `pytest -q` locally
- [ ] I updated docs if behavior changed
- [ ] I requested review from maintainers

## Screenshots/Output (if useful)
Paste logs or screenshots here.
